### PR TITLE
User Configurable DUID

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -3870,10 +3870,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 
 	if (!empty($wancfg['dhcp6-duid']) {
 	// Write the DUID file
-		$dhcp6duid = $wancfg['dhcp6-duid'];
-		if(!write_dhcp6_duid($wancfg['dhcp6-duid'])) {
-			log_error(gettext("Failed to write user DUID file!"));
-		}
+		write_dhcp6_duid($wancfg['dhcp6-duid']));
 	}
 
 	if ($wancfg['adv_dhcp6_config_file_override']) {
@@ -3982,11 +3979,10 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 		$rtsoldscript .= "/bin/sleep 1\n";
 	}
 	$debugOption = isset($wancfg['dhcp6debug']) ? "-D" : "-d";
-	$noreleaseOption = isset($wancfg['dhcp6norelease']) ? "-n" : "";
 	
 	/* add the start of dhcp6c to the rtsold script if we are going to wait for ra */
 	if (!isset($wancfg['dhcp6withoutra'])) {
-		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
+		$rtsoldscript .= "/usr/local/sbin/dhcp6c {$debugOption}-c {$g['varetc_path']}/dhcp6c_{$interface}.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}\n";
 		$rtsoldscript .= "/usr/bin/logger -t rtsold \"Starting dhcp6 client for interface {$interface}({$wanif})\"\n";
 	}
 	/* Add wide-dhcp6c shell script here. Because we can not pass a argument to it. */
@@ -4012,7 +4008,7 @@ function interface_dhcpv6_configure($interface = "wan", $wancfg) {
 	if (isset($wancfg['dhcp6withoutra'])) {
 		kill_dhcp6client_process($wanif);
 
-		mwexec("/usr/local/sbin/dhcp6c {$debugOption} {$noreleaseOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
+		mwexec("/usr/local/sbin/dhcp6c {$debugOption} -c {$g['varetc_path']}/dhcp6c_wan.conf -p {$g['varrun_path']}/dhcp6c_{$wanif}.pid {$wanif}");
 		mwexec("/usr/bin/logger -t info 'Starting dhcp6 client for interface wan({$wanif} in DHCP6 without RA mode)'");
 	}
 	mwexec("/usr/sbin/rtsold -1 -p {$g['varrun_path']}/rtsold_{$wanif}.pid -O {$g['varetc_path']}/rtsold_{$wanif}_script.sh {$wanif}");

--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -2491,16 +2491,20 @@ function get_smart_drive_list() {
 /* Write the DHCP6 DUID file */
 function write_dhcp6_duid($duidfile) {
 	// Create the hex array from the dhcp6duid config entry and write to file
-				
-	$temp = str_replace(":","",$duidfile);
-	$duid_binstring = pack("H*",$temp);
-	if ($fd = fopen("/var/db/dhcp6c_duid", "wb")){
-		fwrite($fd, $duid_binstring);
-		fclose($fd);
-		return true;
+	if(is_duid($duidfile))
+	{
+		$temp = str_replace(":","",$duidfile);
+		$duid_binstring = pack("H*",$temp);
+		if ($fd = fopen("/var/db/dhcp6c_duid", "wb")) {
+			fwrite($fd, $duid_binstring);
+			fclose($fd);
+			return;
+		}
+		else {
+			log_error(gettext("Error: attempting to write DUID file - File write error"));
+			return;
+		}
 	}
-	else {
-		return false;
-	}
+	log_error(gettext("Error: attempting to write DUID file - Invalid DUID detected"));
 }
 ?>

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -285,7 +285,6 @@ switch ($wancfg['ipaddrv6']) {
 		$pconfig['dhcp6usev4iface'] = isset($wancfg['dhcp6usev4iface']);
 		$pconfig['dhcp6debug'] = isset($wancfg['dhcp6debug']);
 		$pconfig['dhcp6withoutra'] = isset($wancfg['dhcp6withoutra']);
-		$pconfig['dhcp6norelease'] = isset($wancfg['dhcp6norelease']);
 		break;
 	case "6to4":
 		$pconfig['type6'] = "6to4";
@@ -986,7 +985,6 @@ if ($_POST['apply']) {
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
 		unset($wancfg['dhcp6withoutra']);
-		unset($wancfg['dhcp6norelease']);
 		unset($wancfg['prefix-6rd']);
 		unset($wancfg['prefix-6rd-v4plen']);
 		unset($wancfg['gateway-6rd']);
@@ -1236,9 +1234,6 @@ if ($_POST['apply']) {
 
 				if ($_POST['dhcp6withoutra'] == "yes") {
 					$wancfg['dhcp6withoutra'] = true;
-				}
-				if ($_POST['dhcp6norelease'] == "yes") {
-					$wancfg['dhcp6norelease'] = true;
 				}
 				if (!empty($_POST['adv_dhcp6_interface_statement_send_options'])) {
 					$wancfg['adv_dhcp6_interface_statement_send_options'] = $_POST['adv_dhcp6_interface_statement_send_options'];
@@ -2144,12 +2139,6 @@ $section->addInput(new Form_Checkbox(
 	'Do not wait for a RA',
 	'Required by some ISPs, especially those not using PPPoE',
 	$pconfig['dhcp6withoutra']
-));
-$section->addInput(new Form_Checkbox(
-	'dhcp6norelease',
-	'Do not allow PD/Address release',
-	'dhcp6c will send a release to the ISP on exit by default. Some ISPs then release the allocated address or prefix. This option prevents that signal ever being sent',
-	$pconfig['dhcp6norelease']
 ));
 $section->addInput(new Form_Input(
 	'dhcp6-duid',


### PR DESCRIPTION
Allows the user to specify a DUID. The DUID is stored in config and
created written to /var/db/ on call of interface_dhcpv6_configure.