### PR TITLE
dhcp6c Advanced config fix

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -4410,7 +4410,7 @@ function DHCP6_Config_File_Advanced($interface, $wancfg, $wanif) {
 
 		if (is_numeric($wancfg['adv_dhcp6_prefix_interface_statement_sla_id'])) {
 			$id_assoc_statement_prefix .= "\n\tprefix-interface";
-			$id_assoc_statement_prefix .= " {$wanif}";
+			$id_assoc_statement_prefix .= " {$wancfg['adv_dhcp6_prefix_selected_interface']}";
 			$id_assoc_statement_prefix .= " {\n";
 			$id_assoc_statement_prefix .= "\t\tsla-id {$wancfg['adv_dhcp6_prefix_interface_statement_sla_id']};\n";
 			if (($wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] >= 0) &&
@@ -5132,8 +5132,7 @@ function get_real_interface($interface = "wan", $family = "all", $realv6iface = 
 							case 'ppp':
 							case 'l2tp':
 							case 'pptp':
-								// Added catch for static v6 but using v4 link. Sets things to use pppoe link
-								if ((isset($cfg['dhcp6usev4iface']) && $realv6iface === false) || isset($cfg['ipv6usev4iface'])) {
+								if (isset($cfg['dhcp6usev4iface']) && $realv6iface === false) {
 									$wanif = $cfg['if'];
 								} else {
 									$parents = get_parent_interface($interface);

--- a/src/usr/local/www/interfaces.php
+++ b/src/usr/local/www/interfaces.php
@@ -228,6 +228,7 @@ $pconfig['adv_dhcp6_id_assoc_statement_prefix_vltime'] = $wancfg['adv_dhcp6_id_a
 
 $pconfig['adv_dhcp6_prefix_interface_statement_sla_id'] = $wancfg['adv_dhcp6_prefix_interface_statement_sla_id'];
 $pconfig['adv_dhcp6_prefix_interface_statement_sla_len'] = $wancfg['adv_dhcp6_prefix_interface_statement_sla_len'];
+$pconfig['adv_dhcp6_prefix_selected_interface'] = $wancfg['adv_dhcp6_prefix_selected_interface'];
 
 $pconfig['adv_dhcp6_authentication_statement_authname'] = $wancfg['adv_dhcp6_authentication_statement_authname'];
 $pconfig['adv_dhcp6_authentication_statement_protocol'] = $wancfg['adv_dhcp6_authentication_statement_protocol'];
@@ -313,7 +314,6 @@ switch ($wancfg['ipaddrv6']) {
 	default:
 		if (is_ipaddrv6($wancfg['ipaddrv6'])) {
 			$pconfig['type6'] = "staticv6";
-			$pconfig['ipv6usev4iface'] = isset($wancfg['ipv6usev4iface']);
 			$pconfig['ipaddrv6'] = $wancfg['ipaddrv6'];
 			$pconfig['subnetv6'] = $wancfg['subnetv6'];
 			$pconfig['gatewayv6'] = $wancfg['gatewayv6'];
@@ -1048,7 +1048,6 @@ if ($_POST['apply']) {
 		unset($wancfg['dhcp6-ia-pd-send-hint']);
 		unset($wancfg['dhcp6prefixonly']);
 		unset($wancfg['dhcp6usev4iface']);
-		unset($wancfg['ipv6usev4iface']);
 		unset($wancfg['dhcp6debug']);
 		unset($wancfg['track6-interface']);
 		unset($wancfg['track6-prefix-id']);
@@ -1095,6 +1094,7 @@ if ($_POST['apply']) {
 
 		unset($wancfg['adv_dhcp6_prefix_interface_statement_sla_id']);
 		unset($wancfg['adv_dhcp6_prefix_interface_statement_sla_len']);
+		unset($wancfg['adv_dhcp6_prefix_selected_interface']);
 
 		unset($wancfg['adv_dhcp6_authentication_statement_authname']);
 		unset($wancfg['adv_dhcp6_authentication_statement_protocol']);
@@ -1277,9 +1277,6 @@ if ($_POST['apply']) {
 			case "staticv6":
 				$wancfg['ipaddrv6'] = $_POST['ipaddrv6'];
 				$wancfg['subnetv6'] = $_POST['subnetv6'];
-				if ($_POST['ipv6usev4iface'] == "yes") {
-					$wancfg['ipv6usev4iface'] = true;
-				}
 				if ($_POST['gatewayv6'] != "none") {
 					$wancfg['gatewayv6'] = $_POST['gatewayv6'];
 				}
@@ -1361,7 +1358,9 @@ if ($_POST['apply']) {
 				if (is_numericint($_POST['adv_dhcp6_prefix_interface_statement_sla_len'])) {
 					$wancfg['adv_dhcp6_prefix_interface_statement_sla_len'] = $_POST['adv_dhcp6_prefix_interface_statement_sla_len'];
 				}
-
+				if (!empty($_POST['adv_dhcp6_prefix_selected_interface'])) {
+					$wancfg['adv_dhcp6_prefix_selected_interface'] = $_POST['adv_dhcp6_prefix_selected_interface'];
+				}
 				if (!empty($_POST['adv_dhcp6_authentication_statement_authname'])) {
 					$wancfg['adv_dhcp6_authentication_statement_authname'] = $_POST['adv_dhcp6_authentication_statement_authname'];
 				}
@@ -1900,13 +1899,6 @@ $section->addInput(new Form_IpAddress(
 	'V6'
 ))->addMask('subnetv6', $pconfig['subnetv6'], 128);
 
-$section->addInput(new Form_Checkbox(
-	'ipv6usev4iface',
-	'Use IPv4 connectivity as parent interface',
-	'IPv6 will use the IPv4 connectivity link (PPPoE)',
-	$pconfig['ipv6usev4iface']
-));
-
 $group = new Form_Group('IPv6 Upstream gateway');
 
 $group->add(new Form_Select(
@@ -2386,6 +2378,17 @@ $group->add(new Form_Input(
 	'text',
 	$pconfig['adv_dhcp6_prefix_interface_statement_sla_len']
 ))->sethelp('sla-len');
+
+$section->add($group);
+
+$group = new Form_Group('Select prefix interface');
+
+$group->add(new Form_Input(
+	'adv_dhcp6_prefix_selected_interface',
+	null,
+	'text',
+	$pconfig['adv_dhcp6_prefix_selected_interface']
+))->sethelp('Select Prefix Interface');
 
 $section->add($group);
 


### PR DESCRIPTION
Current code tries to apply any PD to the  WAN interface when using Advanced Configuration - not useful. These changes enable the user to specify the interface by entering the REAL Inteface, i.e. RE1